### PR TITLE
fix: Generate channels from protocol.yml

### DIFF
--- a/.github/workflows/patchright_workflow.yml
+++ b/.github/workflows/patchright_workflow.yml
@@ -71,6 +71,14 @@ jobs:
           cd playwright
           node "../patchright_driver_patch.js"
 
+      - name: Generate Playwright Channels
+        if: steps.version_check.outputs.proceed == 'true'
+        # Ignore the error exit code, as the script exits 1 when a file is modified.
+        continue-on-error: true
+        run: |
+          cd playwright
+          node utils/generate_channels.js
+
       - name: Build Patchright Driver
         if: steps.version_check.outputs.proceed == 'true'
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "devDependencies": {
-        "ts-morph": "^23.0.0"
+        "ts-morph": "^23.0.0",
+        "yaml": "^2.7.0"
     },
     "type": "module"
 }

--- a/patchright_driver_patch.js
+++ b/patchright_driver_patch.js
@@ -1,4 +1,6 @@
+import fs from "node:fs/promises";
 import { Project, SyntaxKind, IndentationText } from "ts-morph";
+import YAML from "yaml";
 
 const project = new Project({
   manipulationSettings: {
@@ -1461,146 +1463,16 @@ if (workerDispatcherEvaluateExpressionHandleCall && workerDispatcherEvaluateExpr
       workerDispatcherEvaluateExpressionHandleCall.addArgument("params.isolatedContext");
 }
 
-// ----------------------------
-// protocol/validator.ts
-// ----------------------------
-const validatorSourceFile = project.addSourceFileAtPath(
-  "packages/playwright-core/src/protocol/validator.ts",
-);
-const assignments = validatorSourceFile.getDescendantsOfKind(SyntaxKind.BinaryExpression);
-const frameEvaluateParamsAssignment = assignments.find(assignment => {
-  const left = assignment.getLeft();
-    const right = assignment.getRight();
-  if (left.getText() !== "scheme.FrameEvaluateExpressionParams") {
-    return false;
-  }
-  return right.isKind(SyntaxKind.CallExpression) && right.getExpression().getText() === "tObject";
-});
-if (frameEvaluateParamsAssignment) {
-  const callExpression = frameEvaluateParamsAssignment.getRight().asKind(SyntaxKind.CallExpression);
-  if (callExpression) {
-    const objectArg = callExpression.getArguments()[0];
-    if (objectArg && objectArg.isKind(SyntaxKind.ObjectLiteralExpression)) {
-      objectArg.addPropertyAssignment({
-        name: "isolatedContext",
-        initializer: "tBoolean"
-      });
-    }
-  }
-}
-const jsHandleEvaluateExpressionParamsAssignment = assignments.find(assignment => {
-  const left = assignment.getLeft();
-    const right = assignment.getRight();
-  if (left.getText() !== "scheme.JSHandleEvaluateExpressionParams") {
-    return false;
-  }
-  return right.isKind(SyntaxKind.CallExpression) && right.getExpression().getText() === "tObject";
-});
-if (jsHandleEvaluateExpressionParamsAssignment) {
-  const callExpression = jsHandleEvaluateExpressionParamsAssignment.getRight().asKind(SyntaxKind.CallExpression);
-  if (callExpression) {
-    const objectArg = callExpression.getArguments()[0];
-    if (objectArg && objectArg.isKind(SyntaxKind.ObjectLiteralExpression)) {
-      objectArg.addPropertyAssignment({
-        name: "isolatedContext",
-        initializer: "tBoolean"
-      });
-    }
-  }
-}
-const workerEvaluateExpressionParamsAssignment = assignments.find(assignment => {
-  const left = assignment.getLeft();
-    const right = assignment.getRight();
-  if (left.getText() !== "scheme.WorkerEvaluateExpressionParams") {
-    return false;
-  }
-  return right.isKind(SyntaxKind.CallExpression) && right.getExpression().getText() === "tObject";
-});
-if (workerEvaluateExpressionParamsAssignment) {
-  const callExpression = workerEvaluateExpressionParamsAssignment.getRight().asKind(SyntaxKind.CallExpression);
-  if (callExpression) {
-    const objectArg = callExpression.getArguments()[0];
-    if (objectArg && objectArg.isKind(SyntaxKind.ObjectLiteralExpression)) {
-      objectArg.addPropertyAssignment({
-        name: "isolatedContext",
-        initializer: "tBoolean"
-      });
-    }
-  }
-}
-
-// ----------------------------
-// protocol/channels.d.ts
-// ----------------------------
-const channelsTypeFile = project.addSourceFileAtPath(
-  "packages/protocol/src/channels.d.ts",
-);
-const jsHandleEvaluateTypeAlias = channelsTypeFile.getTypeAlias("JSHandleEvaluateExpressionParams");
-if (jsHandleEvaluateTypeAlias) {
-    const typeLiteral = jsHandleEvaluateTypeAlias.getFirstChildByKind(SyntaxKind.TypeLiteral);
-    if (typeLiteral) {
-        typeLiteral.addProperty({
-            name: "isolatedContext",
-            type: "boolean",
-            hasQuestionToken: true,
-        });
-    }
-}
-const jsHandleEvaluateHandleTypeAlias = channelsTypeFile.getTypeAlias("JSHandleEvaluateHandleExpressionParams");
-if (jsHandleEvaluateHandleTypeAlias) {
-    const typeLiteral = jsHandleEvaluateHandleTypeAlias.getFirstChildByKind(SyntaxKind.TypeLiteral);
-    if (typeLiteral) {
-        typeLiteral.addProperty({
-            name: "isolatedContext",
-            type: "boolean",
-            hasQuestionToken: true,
-        });
-    }
-}
-const frameEvaluateTypeAlias = channelsTypeFile.getTypeAlias("FrameEvaluateExpressionParams");
-if (frameEvaluateTypeAlias) {
-    const typeLiteral = frameEvaluateTypeAlias.getFirstChildByKind(SyntaxKind.TypeLiteral);
-    if (typeLiteral) {
-        typeLiteral.addProperty({
-            name: "isolatedContext",
-            type: "boolean",
-            hasQuestionToken: true,
-        });
-    }
-}
-const frameEvaluateHandleTypeAlias = channelsTypeFile.getTypeAlias("FrameEvaluateExpressionHandleParams");
-if (frameEvaluateHandleTypeAlias) {
-    const typeLiteral = frameEvaluateHandleTypeAlias.getFirstChildByKind(SyntaxKind.TypeLiteral);
-    if (typeLiteral) {
-        typeLiteral.addProperty({
-            name: "isolatedContext",
-            type: "boolean",
-            hasQuestionToken: true,
-        });
-    }
-}
-const workerEvaluateTypeAlias = channelsTypeFile.getTypeAlias("WorkerEvaluateExpressionParams");
-if (workerEvaluateTypeAlias) {
-    const typeLiteral = workerEvaluateTypeAlias.getFirstChildByKind(SyntaxKind.TypeLiteral);
-    if (typeLiteral) {
-        typeLiteral.addProperty({
-            name: "isolatedContext",
-            type: "boolean",
-            hasQuestionToken: true,
-        });
-    }
-}
-const workerEvaluateHandleTypeAlias = channelsTypeFile.getTypeAlias("WorkerEvaluateExpressionHandleParams");
-if (workerEvaluateHandleTypeAlias) {
-    const typeLiteral = workerEvaluateHandleTypeAlias.getFirstChildByKind(SyntaxKind.TypeLiteral);
-    if (typeLiteral) {
-        typeLiteral.addProperty({
-            name: "isolatedContext",
-            type: "boolean",
-            hasQuestionToken: true,
-        });
-    }
-}
-
 // Save the changes without reformatting
 project.saveSync();
+
+// ----------------------------
+// protocol/protocol.yml
+// ----------------------------
+const protocol = YAML.parse(await fs.readFile("packages/protocol/src/protocol.yml", "utf8"));
+for (const type of ["Frame", "JSHandle", "Worker"]) {
+    const commands = protocol[type].commands;
+    commands.evaluateExpression.parameters.isolatedContext = "boolean?";
+    commands.evaluateExpressionHandle.parameters.isolatedContext = "boolean?";
+}
+await fs.writeFile("packages/protocol/src/protocol.yml", YAML.stringify(protocol));


### PR DESCRIPTION
Fix https://github.com/Kaliiiiiiiiii-Vinyzu/patchright/issues/43

---

The [YAML](https://www.npmjs.com/package/yaml) library doesn't keep the formatting. So `protocol.yml` loses its comments and the indentation changes. I don't think it's a problem.

---

Changes made from the `protocol.yml` file are different from changes made with ts-morph. I don't know if the added property `isolatedContext` in the `*EvaluateExpressionOptions` and `*EvaluateExpressionHandleOptions` types is normal. I think the other changes (`;` ➔ `,` and `tBoolean` ➔ `tOptional(tBoolean),`) are good.

- `channels.d.ts`

  ```diff
    export type FrameEvaluateExpressionParams = {
      expression: string,
      isFunction?: boolean,
      arg: SerializedArgument,
  -   isolatedContext?: boolean;
  +   isolatedContext?: boolean,
    };
    export type FrameEvaluateExpressionOptions = {
      isFunction?: boolean,
  +   isolatedContext?: boolean,
    };
    export type FrameEvaluateExpressionHandleParams = {
      expression: string,
      isFunction?: boolean,
      arg: SerializedArgument,
  -   isolatedContext?: boolean;
  +   isolatedContext?: boolean,
    };
    export type FrameEvaluateExpressionHandleOptions = {
      isFunction?: boolean,
  +   isolatedContext?: boolean,
    };

    export type WorkerEvaluateExpressionParams = {
      expression: string,
      isFunction?: boolean,
      arg: SerializedArgument,
  -   isolatedContext?: boolean;
  +   isolatedContext?: boolean,
    };
    export type WorkerEvaluateExpressionOptions = {
      isFunction?: boolean,
  +   isolatedContext?: boolean,
    };
    export type WorkerEvaluateExpressionHandleParams = {
      expression: string,
      isFunction?: boolean,
      arg: SerializedArgument,
  -   isolatedContext?: boolean;
  +   isolatedContext?: boolean,
    };
    export type WorkerEvaluateExpressionHandleOptions = {
      isFunction?: boolean,
  +   isolatedContext?: boolean,
    };

    export type JSHandleEvaluateExpressionParams = {
      expression: string,
      isFunction?: boolean,
      arg: SerializedArgument,
  -   isolatedContext?: boolean;
  +   isolatedContext?: boolean,
    };
    export type JSHandleEvaluateExpressionOptions = {
      isFunction?: boolean,
  +   isolatedContext?: boolean,
    };
    export type JSHandleEvaluateExpressionHandleParams = {
      expression: string,
      isFunction?: boolean,
      arg: SerializedArgument,
  +   isolatedContext?: boolean,
    };
    export type JSHandleEvaluateExpressionHandleOptions = {
      isFunction?: boolean,
  +   isolatedContext?: boolean,
    };
  ```

- `validator.ts`

  ```diff
    scheme.FrameEvaluateExpressionParams = tObject({
      expression: tString,
      isFunction: tOptional(tBoolean),
      arg: tType('SerializedArgument'),
  -   isolatedContext: tBoolean
  +   isolatedContext: tOptional(tBoolean),
    });
    scheme.FrameEvaluateExpressionHandleParams = tObject({
      expression: tString,
      isFunction: tOptional(tBoolean),
      arg: tType('SerializedArgument'),
  +   isolatedContext: tOptional(tBoolean),
    });

    scheme.WorkerEvaluateExpressionParams = tObject({
      expression: tString,
      isFunction: tOptional(tBoolean),
      arg: tType('SerializedArgument'),
  -   isolatedContext: tBoolean
  +   isolatedContext: tOptional(tBoolean),
    });
    scheme.WorkerEvaluateExpressionHandleParams = tObject({
      expression: tString,
      isFunction: tOptional(tBoolean),
      arg: tType('SerializedArgument'),
  +   isolatedContext: tOptional(tBoolean),
    });

    scheme.JSHandleEvaluateExpressionParams = tObject({
      expression: tString,
      isFunction: tOptional(tBoolean),
      arg: tType('SerializedArgument'),
  -   isolatedContext: tBoolean
  +   isolatedContext: tOptional(tBoolean),
    });
    scheme.JSHandleEvaluateExpressionHandleParams = tObject({
      expression: tString,
      isFunction: tOptional(tBoolean),
      arg: tType('SerializedArgument'),
  +   isolatedContext: tOptional(tBoolean),
    });
  ```

---

I only tested the patch. I didn't test the workflow.