### PR TITLE
Remove useless InitScript class patch

### DIFF
--- a/patchright_driver_patch.js
+++ b/patchright_driver_patch.js
@@ -1851,25 +1851,6 @@ this.source = createPageBindingScript(name, needsHandle);
 this.needsHandle = needsHandle;`,
 );
 
-// ------- InitScript Class -------
-const initScriptClass = pageSourceFile.getClass("InitScript");
-// -- InitScript Constructor --
-const initScriptConstructor = initScriptClass.getConstructors()[0];
-const initScriptConstructorAssignment = initScriptConstructor
-  .getBody()
-  ?.getStatements()
-  .find(
-    (statement) =>
-      statement.getKind() === SyntaxKind.ExpressionStatement &&
-      statement.getText().includes("this.source = `(() => {"),
-  );
-// Remove unnecessary, detectable code from the constructor
-if (initScriptConstructorAssignment) {
-  initScriptConstructorAssignment.replaceWithText(
-    `this.source = \`(() => { \${source} })();\`;`,
-  );
-}
-
 // ------- Worker Class -------
 const workerClass = pageSourceFile.getClass("Worker");
 // -- evaluateExpression Method --


### PR DESCRIPTION
Creation of `__pw_init_scripts__*` ([new name of `__pwInitScripts`](https://github.com/microsoft/playwright/pull/35721/files#diff-087773eea292da9db5a3f27de8f1a2940cdb895383ad750c3cd8e01772a35b40R909-R917)) global variables has been removed in [microsoft/playwright#35975](https://github.com/microsoft/playwright/pull/35975/files#diff-087773eea292da9db5a3f27de8f1a2940cdb895383ad750c3cd8e01772a35b40L910-L918) (but **not yet released**). I think the `InitScript` class constructor patch is no longer necessary.