### PR TITLE
FEAT: replace "npx playwright install" error message with "npx patchright install"

### DIFF
--- a/driver_patches/index.js
+++ b/driver_patches/index.js
@@ -17,3 +17,4 @@ export * from "./pageDispatcherPatch.js";
 export * from "./pagePatch.js";
 export * from "./utilityScriptSerializersPatch.js";
 export * from "./XPathSelectorEnginePatch.js";
+export * from "./serverRegistryIndex.js";

--- a/driver_patches/serverRegistryIndex.js
+++ b/driver_patches/serverRegistryIndex.js
@@ -1,0 +1,20 @@
+import { Project, SyntaxKind } from "ts-morph";
+
+// ----------------------------
+// server/registry/index.ts
+// ----------------------------
+export function patchServerRegistryIndex(project) {
+  const sourceFile = project.addSourceFileAtPath("packages/playwright-core/src/server/registry/index.ts");
+
+  const fn = sourceFile.getFunctionOrThrow("buildPlaywrightCLICommand");
+
+  const switchStmt = fn.getFirstDescendantByKindOrThrow(SyntaxKind.SwitchStatement);
+
+  const defaultClause = switchStmt.getFirstDescendantByKindOrThrow(SyntaxKind.DefaultClause);
+
+  const returnStmt = defaultClause.getFirstDescendantByKindOrThrow(SyntaxKind.ReturnStatement);
+
+  const oldText = returnStmt.getText();
+  const newText = oldText.replace("playwright", "patchright");
+  returnStmt.replaceWithText(newText);
+}

--- a/patchright_driver_patch.js
+++ b/patchright_driver_patch.js
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import path from 'path';
+import path from "path";
 import { Project, SyntaxKind, IndentationText, ObjectLiteralExpression } from "ts-morph";
 import YAML from "yaml";
 
@@ -74,7 +74,7 @@ patches.patchUtilityScriptSerializers(project);
 // ----------------------------
 // server/pageBinding.ts
 // ----------------------------
-patches.patchPageBinding(project)
+patches.patchPageBinding(project);
 // ----------------------------
 // server/clock.ts
 // ----------------------------
@@ -105,6 +105,11 @@ patches.patchPageDispatcher(project);
 // ----------------------------
 patches.patchXPathSelectorEngine(project);
 
+// ----------------------------
+// server/registry/index.ts
+// ----------------------------
+patches.patchServerRegistryIndex(project);
+
 // Save the changes without reformatting
 project.saveSync();
 
@@ -113,9 +118,9 @@ project.saveSync();
 // ----------------------------
 const protocol = YAML.parse(await fs.readFile("packages/protocol/src/protocol.yml", "utf8"));
 for (const type of ["Frame", "JSHandle", "Worker"]) {
-    const commands = protocol[type].commands;
-    commands.evaluateExpression.parameters.isolatedContext = "boolean?";
-    commands.evaluateExpressionHandle.parameters.isolatedContext = "boolean?";
+  const commands = protocol[type].commands;
+  commands.evaluateExpression.parameters.isolatedContext = "boolean?";
+  commands.evaluateExpressionHandle.parameters.isolatedContext = "boolean?";
 }
 protocol["Frame"].commands.evalOnSelectorAll.parameters.isolatedContext = "boolean?";
 await fs.writeFile("packages/protocol/src/protocol.yml", YAML.stringify(protocol));


### PR DESCRIPTION
When running patchright without installing browsers, the error message "npx playwright install" appears.
However, this command does not work as intended — users need to run "npx patchright install" instead.

This could confuse users and lead to unnecessary time loss.
To prevent this, the error message in the Playwright code has been updated to replace playwright with patchright.

### Changes
- File : packages/playwright-core/src/server/registry/index.ts
- Line : 1385