### PR TITLE
fix: sort failure after element position format change

### DIFF
--- a/driver_patches/framesPatch.js
+++ b/driver_patches/framesPatch.js
@@ -744,7 +744,7 @@ export function patchFrames(project) {
         }
 
         // Sorting elements by their nodePosition, which is a index to the Element in the DOM tree
-        const getParts = (pos) => (pos || "").split(".").filter(Boolean).map(Number);
+        const getParts = (pos) => (pos || '').split('.').filter(Boolean).map(Number);
         elements.sort((a, b) => {
           const partA = getParts(a.nodePosition);
           const partB = getParts(b.nodePosition);


### PR DESCRIPTION
After commit: [beca5ad3453e8c9ddfc1497600fcd9eba40666d0](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright/commit/beca5ad3453e8c9ddfc1497600fcd9eba40666d0)
The nodePosition format changed from 011/010 to .0.1.1/.0.1.0, causing the sort function failure, thus failed test case in my forked python version on test case:
<img width="573" height="287" alt="image" src="https://github.com/user-attachments/assets/0089510b-0262-4ae6-8c16-96df247120ef" />
 