### PR TITLE
fix: script injection into comments bug

### DIFF
--- a/driver_patches/crNetworkManagerPatch.js
+++ b/driver_patches/crNetworkManagerPatch.js
@@ -341,6 +341,8 @@ export function patchCRNetworkManager(project) {
                         // continue search after the comment
                         searchPos = commentEnd + 3;
                         continue;
+                    } else {
+                        break;
                     }
                 }
 


### PR DESCRIPTION
i found a bug, when some of the html contains comments, patchright will inject scrpts at wrong position.
website: https://tool.lu/ip
html: Simplified version
scrpits will be injected in the comment

```html
<!DOCTYPE html>
<html lang="zh-Hans">
<head>
    <!--[if lt IE 9]>
    <script src="//s1.tool.lu/__/6f8c881821420275fc59b30c6999a75b.js"></script>
    <![endif]-->
    <script src="//s1.tool.lu/__/6f8c88182.js"></script>
    </head>
<body>
<script>
    var _hmt = _hmt || [];
</script>
</body>
</html>
```