### PR TITLE
fix: Remove add init script invoke in for expose binding

### DIFF
--- a/driver_patches/crNetworkManagerPatch.js
+++ b/driver_patches/crNetworkManagerPatch.js
@@ -230,9 +230,6 @@ export function patchCRNetworkManager(project) {
     fulfillMethod.setBodyText(`
       const isTextHtml = response.headers.some((header) => header.name.toLowerCase() === "content-type" && header.value.includes("text/html"));
       var allInjections = [...this._page.delegate._mainFrameSession._evaluateOnNewDocumentScripts];
-      for (const binding of this._page.delegate._browserContext._pageBindings.values()) {
-        if (!allInjections.includes(binding)) allInjections.push(binding);
-      }
       if (isTextHtml && allInjections.length) {
         let useNonce = false;
         let scriptNonce = null;

--- a/driver_patches/crPagePatch.js
+++ b/driver_patches/crPagePatch.js
@@ -281,7 +281,6 @@ export function patchCRPage(project) {
       ]);
       this._exposedBindingNames.push(binding.name);
       this._exposedBindingScripts.push(binding.source);
-      await this._crPage.addInitScript(binding.source);
       //this._client._sendMayFail('Runtime.runIfWaitingForDebugger')`);
       // initBindingMethod.setBodyText(`const [, response] = await Promise.all([
       //   this._client.send('Runtime.addBinding', { name: binding.name }),


### PR DESCRIPTION
I was trying to understand the behavior difference in `expose_binding` and `add_init_script`.

And I realized that seem `addInitScript` not necessary when `_initBinding`, because:

1. invoke `addInitScript` will add the binding wrap to `_evaluateOnNewDocumentScripts`, also we will read it from `_browserContext._pageBindings.values()` too, hence we will inject 2 set of inline scripts when fulfill response when we `new_page` and then navigate which triggers route based init scripts injection
2. Both inline scripts seems not necessary because our `expose_binding` depends on execution context created and `_onExecutionContextCreated`

Thus I make this change hope that it will help reduce the init scripts we injected into HTML doc.

I'm not quite sure if my understanding is adequate enough, please feel free to correct me if I'm wrong, thank you!

Here is a minimal repro case I tried after the change, looks like even remove init scripts injection, the expose binding still functions in proper way:

```python
import asyncio
from patchright.async_api import async_playwright


async def main():
    async with async_playwright() as p:
        try:
            # Step 1: Launch browser and create context
            browser = await p.chromium.launch(
                channel="chrome",
                headless=False
            )
            context = await browser.new_context(viewport=None)

            # Step 2: Expose a function at the context level
            async def log_info(msg):
                print(f"[log_info] {msg}")

            await context.expose_function("log_info", log_info)

            # Step 3: Create a new page
            page = await context.new_page()

            # Step 4: Verify binding exists after new_page()
            log_info_exists1 = await page.evaluate("() => typeof window.log_info === 'function'", isolated_context=False)
            print(f"After new_page, log_info exists = {log_info_exists1}")

            # Step 5: Navigate to a URL
            await page.goto("https://example.com", timeout=0)

            # Step 6: Verify binding persists after navigation
            log_info_exists2 = await page.evaluate("() => typeof window.log_info === 'function'", isolated_context=False)
            print(f"After goto example.com, log_info exists = {log_info_exists2}")

            # Step 7: Test the exposed function actually works
            await page.evaluate("() => window.log_info('foo foo')")

            # Keep browser open for manual inspection
            print("\nPress Enter to close browser...")
            input()
            await browser.close()
        except Exception as e:
            print(f"Error: {e}")
            import traceback
            traceback.print_exc()


asyncio.run(main())
```
Results:
<img width="383" height="60" alt="image" src="https://github.com/user-attachments/assets/bc5a480b-e90c-4538-951e-25572465e46e" />
