### PR TITLE
Exclude captcha, analytics, and tracking requests from networkidle

### DIFF
--- a/driver_patches/framesPatch.ts
+++ b/driver_patches/framesPatch.ts
@@ -1,6 +1,41 @@
 import { type Project, SyntaxKind } from "ts-morph";
 import { assertDefined } from "./utils.ts";
 
+// URL patterns excluded from networkidle calculations.
+// These are captcha providers, analytics, tracking, fraud detection, and session
+// heartbeat endpoints that poll continuously and would prevent networkidle from firing.
+const NETWORKIDLE_EXCLUDED_URL_PATTERNS = [
+	// -- Captcha providers --
+	'challenges.cloudflare.com',
+	'google.com/recaptcha',
+	'www.gstatic.com/recaptcha',
+	'hcaptcha.com',
+	'api.funcaptcha.com',
+	'client-api.arkoselabs.com',
+	// -- Analytics & tracking --
+	'google-analytics.com',
+	'googletagmanager.com',
+	'analytics.google.com',
+	// -- Session recording & heatmaps --
+	'hotjar.com',
+	'fullstory.com',
+	'logrocket.com',
+	'mouseflow.com',
+	'clarity.ms',
+	// -- Telemetry & monitoring --
+	'browser-intake-datadoghq.com',
+	'sentry.io',
+	'newrelic.com',
+	'nr-data.net',
+	// -- Fraud detection --
+	'forter.com',
+	// -- Common polling/heartbeat patterns --
+	'/heartbeat',
+	'/keepalive',
+	'/keep-alive',
+	'/beacon',
+];
+
 // ----------------
 // server/frames.ts
 // ----------------
@@ -27,6 +62,30 @@ export function patchFrames(project: Project) {
 		"frame._iframeWorld = undefined;",
 		"frame._mainWorld = undefined;",
 		"frame._isolatedWorld = undefined;"
+	]);
+
+	// -- _inflightRequestStarted Method (captcha networkidle exclusion) --
+	const inflightStartedMethod = frameManagerClass.getMethodOrThrow("_inflightRequestStarted");
+	const inflightStartedBody = inflightStartedMethod.getBodyOrThrow().asKindOrThrow(SyntaxKind.Block);
+	const faviconCheckStart = assertDefined(
+		inflightStartedBody.getStatements().find(s => s.getText().includes('request._isFavicon')),
+		'_isFavicon check in _inflightRequestStarted'
+	);
+	inflightStartedBody.insertStatements(faviconCheckStart.getChildIndex() + 1, [
+		`const _reqUrl = request.url();`,
+		`if (${JSON.stringify(NETWORKIDLE_EXCLUDED_URL_PATTERNS)}.some(p => _reqUrl.includes(p))) return;`,
+	]);
+
+	// -- _inflightRequestFinished Method (captcha networkidle exclusion) --
+	const inflightFinishedMethod = frameManagerClass.getMethodOrThrow("_inflightRequestFinished");
+	const inflightFinishedBody = inflightFinishedMethod.getBodyOrThrow().asKindOrThrow(SyntaxKind.Block);
+	const faviconCheckFinish = assertDefined(
+		inflightFinishedBody.getStatements().find(s => s.getText().includes('request._isFavicon')),
+		'_isFavicon check in _inflightRequestFinished'
+	);
+	inflightFinishedBody.insertStatements(faviconCheckFinish.getChildIndex() + 1, [
+		`const _reqUrl = request.url();`,
+		`if (${JSON.stringify(NETWORKIDLE_EXCLUDED_URL_PATTERNS)}.some(p => _reqUrl.includes(p))) return;`,
 	]);
 
 	// ------- Frame Class -------

--- a/networkidle-poc/apply_patch.py
+++ b/networkidle-poc/apply_patch.py
@@ -1,0 +1,50 @@
+import importlib.util, sys                                                                                                            
+from pathlib import Path                                        
+
+NETWORKIDLE_EXCLUDED_URL_PATTERNS = [                                                                                                 
+    "challenges.cloudflare.com","google.com/recaptcha","www.gstatic.com/recaptcha",
+    "hcaptcha.com","api.funcaptcha.com","client-api.arkoselabs.com",                                                                  
+    "google-analytics.com","googletagmanager.com","analytics.google.com",                                                             
+    "hotjar.com","fullstory.com","logrocket.com","mouseflow.com","clarity.ms",                                                        
+    "browser-intake-datadoghq.com","sentry.io","newrelic.com","nr-data.net",                                                          
+    "forter.com","/heartbeat","/keepalive","/keep-alive","/beacon",                                                                   
+]                                                                                                                                     
+PATCH_MARKER = "/* networkidle-exclusion-list */"                                                                                     
+PATCH_SNIPPET = (                                                                                                                     
+    f'    {PATCH_MARKER}\n'                                     
+    f'    const _reqUrl = request.url();\n'                                                                                           
+    f'    if ({NETWORKIDLE_EXCLUDED_URL_PATTERNS!r}.some(p => _reqUrl.includes(p))) return;\n'                                        
+).replace("'", '"')                                                                                                                   
+                                                                                                                                    
+VANILLA_STARTED = (                                                                                                                   
+    "  _inflightRequestStarted(request) {\n    const frame = request.frame();\n"                                                      
+    "    if (request._isFavicon)\n      return;\n"                                                                                    
+)                                                                                                                                     
+PATCHED_STARTED = VANILLA_STARTED + PATCH_SNIPPET                                                                                     
+VANILLA_FINISHED = (                                                                                                                  
+    "  _inflightRequestFinished(request) {\n    const frame = request.frame();\n"
+    "    if (request._isFavicon)\n      return;\n"                                                                                    
+)                                                                                                                                     
+PATCHED_FINISHED = VANILLA_FINISHED + PATCH_SNIPPET
+                                                                                                                                    
+def driver_frames_path():                                                                                                             
+    spec = importlib.util.find_spec("patchright")
+    return Path(spec.origin).parent / "driver" / "package" / "lib" / "server" / "frames.js"                                           
+                                                                                                                                    
+def apply():
+    p = driver_frames_path(); src = p.read_text()                                                                                     
+    if PATCH_MARKER in src: print(f"already patched: {p}"); return                                                                    
+    if VANILLA_STARTED not in src or VANILLA_FINISHED not in src:                                                                     
+        raise SystemExit("could not locate vanilla _inflightRequest* methods")                                                        
+    p.write_text(src.replace(VANILLA_STARTED, PATCHED_STARTED, 1).replace(VANILLA_FINISHED, PATCHED_FINISHED, 1))                     
+    print(f"patched: {p}")                                                                                                            
+                                                                                                                                    
+def revert():                                                                                                                         
+    p = driver_frames_path(); src = p.read_text()               
+    if PATCH_MARKER not in src: print(f"already vanilla: {p}"); return                                                                
+    p.write_text(src.replace(PATCHED_STARTED, VANILLA_STARTED, 1).replace(PATCHED_FINISHED, VANILLA_FINISHED, 1))                     
+    print(f"reverted: {p}")                                                                                                           
+                                                                                                                                    
+if __name__ == "__main__":                                                                                                            
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "apply"         
+    {"apply": apply, "revert": revert}[cmd]()          

--- a/networkidle-poc/runner.py
+++ b/networkidle-poc/runner.py
@@ -1,0 +1,35 @@
+import sys, time                                                                                                                      
+from importlib.metadata import version as pkg_version
+from typing import Optional                                                                                                           
+from patchright.sync_api import sync_playwright                                                                                       
+from server import get_heartbeat_count, reset_heartbeat_count, serve
+                                                                                                                                    
+URL = "http://127.0.0.1:8765/"                                  
+NETWORKIDLE_TIMEOUT_MS = 15_000                                                                                                       
+                                                                                                                                    
+def main(label):
+    print(f"=== {label} | patchright {pkg_version('patchright')} ===")                                                                
+    serve(); time.sleep(0.2)                                                                                                          
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)                                                                                    
+        page = browser.new_context().new_page()                                                                                       
+        t0 = time.monotonic()
+        page.goto(URL, wait_until="load")                                                                                             
+        print(f"page load complete in {(time.monotonic()-t0)*1000:.0f} ms")                                                           
+        reset_heartbeat_count()
+        time.sleep(3)                                                                                                                 
+        c = get_heartbeat_count()                               
+        print(f"/heartbeat requests received in 3s after load: {c} (~{c/3:.1f}/sec)")                                                 
+        t1 = time.monotonic()                                                                                                         
+        err: Optional[str] = None
+        try:                                                                                                                          
+            page.wait_for_load_state("networkidle", timeout=NETWORKIDLE_TIMEOUT_MS)
+        except Exception as exc:                                                                                                      
+            err = type(exc).__name__ + ": " + str(exc).splitlines()[0]
+        elapsed = (time.monotonic() - t1) * 1000                                                                                      
+        print(f"networkidle: {'TIMED OUT after' if err else 'fired after'} {elapsed:.0f} ms"                                          
+            + (f" — {err}" if err else ""))                                                                                         
+        browser.close()                                                                                                               
+                                                                                                                                    
+if __name__ == "__main__":                                      
+    main(sys.argv[1] if len(sys.argv) > 1 else "run")    

--- a/networkidle-poc/server.py
+++ b/networkidle-poc/server.py
@@ -1,0 +1,46 @@
+import http.server, socketserver, threading, time
+from pathlib import Path                                                                                                              
+
+PAGE = (Path(__file__).parent / "test_page.html").read_text()                                                                         
+heartbeat_count = 0                                             
+heartbeat_lock = threading.Lock()                                                                                                     
+                                                                
+def reset_heartbeat_count():                                                                                                          
+    global heartbeat_count                                      
+    with heartbeat_lock:
+        heartbeat_count = 0                                                                                                           
+
+def get_heartbeat_count():                                                                                                            
+    with heartbeat_lock:                                        
+        return heartbeat_count
+
+class Handler(http.server.BaseHTTPRequestHandler):                                                                                    
+    def do_GET(self):
+        if self.path == "/" or self.path.startswith("/index"):                                                                        
+            body = PAGE.encode()                                
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))                                                                        
+            self.end_headers(); self.wfile.write(body); return
+        if self.path.startswith("/heartbeat"):                                                                                        
+            global heartbeat_count                              
+            with heartbeat_lock:                                                                                                      
+                heartbeat_count += 1                            
+            time.sleep(0.6)  # 600ms response, 200ms client interval => always ≥1 inflight
+            body = b'{"ok":true}'                                                                                                     
+            self.send_response(200)                                                                                                   
+            self.send_header("Content-Type", "application/json")                                                                      
+            self.send_header("Content-Length", str(len(body)))                                                                        
+            self.end_headers(); self.wfile.write(body); return  
+        self.send_response(404); self.end_headers()                                                                                   
+    def log_message(self, *a, **kw): return
+                                                                                                                                    
+class ReusableTCPServer(socketserver.ThreadingTCPServer):                                                                             
+    allow_reuse_address = True                                                                                                        
+                                                                                                                                    
+def serve(port=8765):                                                                                                                 
+    httpd = ReusableTCPServer(("127.0.0.1", port), Handler)
+    httpd.daemon_threads = True                                                                                                       
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()                                                                                                                         
+    return t

--- a/networkidle-poc/test_page.html
+++ b/networkidle-poc/test_page.html
@@ -1,0 +1,18 @@
+<!doctype html>                                                                                                                       
+<html><body>                                                    
+  <h1>networkidle PoC</h1>
+  <pre id="log"></pre>
+  <script>                                                                                                                            
+    const log = document.getElementById('log');
+    let n = 0;                                                                                                                        
+    function poll() {                                                                                                                 
+      n += 1;
+      log.textContent = `heartbeat #${n}`;                                                                                            
+      fetch('/heartbeat?n=' + n).catch(() => {});               
+    }                                                                                                                                 
+    window.addEventListener('load', () => {
+      setInterval(poll, 200);                                                                                                         
+      poll();                                                                                                                         
+    });
+  </script>                                                                                                                           
+</body></html>


### PR DESCRIPTION
## Summary

Playwright's `networkidle` waits for 500ms with zero inflight requests. Captcha providers, analytics SDKs, fraud detection, and session heartbeat endpoints poll continuously, preventing `networkidle` from ever firing on real-world sites.

This adds URL-based filtering to `_inflightRequestStarted` and `_inflightRequestFinished` in `FrameManager`, following the existing `_isFavicon` exclusion pattern. Requests matching known polling domains are never added to the inflight set, so they don't delay the idle timer.

## Approach

- Uses **ts-morph AST patching** (project convention) — inserts the check right after the `_isFavicon` early return in both methods
- The compiled output is indistinguishable from normal Playwright code (no markers, no post-compilation patching)
- Follows the exact same pattern as the existing `_isFavicon` exclusion

## Excluded patterns

| Category | Domains |
|---|---|
| Captcha | `challenges.cloudflare.com`, `google.com/recaptcha`, `www.gstatic.com/recaptcha`, `hcaptcha.com`, `api.funcaptcha.com`, `client-api.arkoselabs.com` |
| Analytics | `google-analytics.com`, `googletagmanager.com`, `analytics.google.com` |
| Session recording | `hotjar.com`, `fullstory.com`, `logrocket.com`, `mouseflow.com`, `clarity.ms` |
| Telemetry | `browser-intake-datadoghq.com`, `sentry.io`, `newrelic.com`, `nr-data.net` |
| Fraud detection | `forter.com` |
| Generic | `/heartbeat`, `/keepalive`, `/keep-alive`, `/beacon` |

## How it works

The generated code in `frames.ts` after patching:

```typescript
private _inflightRequestStarted(request: network.Request) {
  const frame = request.frame()!;
  if (request._isFavicon)
    return;
  const _reqUrl = request.url();
  if (["challenges.cloudflare.com","google.com/recaptcha",...].some(p => _reqUrl.includes(p)))
    return;
  frame._inflightRequests.add(request);
  if (frame._inflightRequests.size === 1)
    frame._stopNetworkIdleTimer();
}
```

## Context

This was previously submitted as [patchright-python#111](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-python/pull/111) which patched compiled JS post-extraction. Per feedback from @Vinyzu, this version:
- Lives in the driver repo where it belongs
- Uses ts-morph AST patching (project convention)
- Compiles naturally with no detectable artifacts