### PR TITLE
fix: only add script-src to CSP when default-src is not present

### DIFF
--- a/driver_patches/crNetworkManagerPatch.ts
+++ b/driver_patches/crNetworkManagerPatch.ts
@@ -181,6 +181,7 @@ export function patchCRNetworkManager(project: Project) {
 
 		const fixedDirectives = [];
 		let hasScriptSrc = false;
+		let hasDefaultSrc = false;
 
 		const addIfMissing = (values: string[], ...items: string[]) => {
 			for (const item of items)
@@ -249,14 +250,20 @@ export function patchCRNetworkManager(project: Project) {
 					fixedDirectives.push(\`frame-ancestors \${frameAncestorValues}\`);
 					break;
 
+				case 'default-src':
+					hasDefaultSrc = true;
+					fixedDirectives.push(directive);
+					break;
+
 				default:
 					// Keep other directives as-is
 					fixedDirectives.push(directive);
 			}
 		}
 
-		// Add script-src if it doesn't exist (for our injected scripts)
-		if (!hasScriptSrc) {
+		// Add script-src for our injected scripts only when it's missing AND a
+		// default-src exists to override.
+		if (!hasScriptSrc && hasDefaultSrc) {
 			fixedDirectives.push(
 				scriptNonce
 					? \`script-src 'self' 'unsafe-eval' 'nonce-\${scriptNonce}' *\`

--- a/driver_patches/crNetworkManagerPatch.ts
+++ b/driver_patches/crNetworkManagerPatch.ts
@@ -192,7 +192,7 @@ export function patchCRNetworkManager(project: Project) {
 
 		for (let directive of directives) {
 			// Improved directive parsing to handle more edge cases
-			const directiveMatch = directive.match(/^([a-zA-Z-]+)\\s+(.*)$/);
+			const directiveMatch = directive.match(/^([a-zA-Z-]+)(?:\\s+(.*))?$/);
 			if (!directiveMatch) {
 				fixedDirectives.push(directive);
 				continue;


### PR DESCRIPTION
When testing Patchright on a SPA, I ran into the fact that when a page has no `script-src`, `_fixCSP` always adds this one and this  breaks `blob:` workers (`new Worker(URL.createObjectURL(...))`, common in bundled SPAs). With no `worker-src`, the worker falls back to that new `script-src`, and `*` doesn't include `blob:`, so it gets blocked. The same pages work fine in normal Playwright, which doesn't touch the CSP.

We only need to add  `script-src` when there's a `default-src` to override. If there's no `default-src`, scripts are already allowed, so adding it just blocks the worker for no reason.

This fix checks for `default-src` and only adds the `script-src` when it's there (`!hasScriptSrc && hasDefaultSrc`). Nothing changes if `script-src` or `default-src` is already set.

Do you think we can pass this fix? Let me know if you need me to make any further changes.

Thanks!