### PR TITLE
fix: support Playwright v1.62 (fixes #228, #229)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,7 @@
 [submodule "patchright-nodejs"]
 	path = patchright-nodejs
-	url = https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-nodejs.git
-	branch = main
+	# TEMPORARY: points at the fork branch containing the companion fix
+	# (Kaliiiiiiiiii-Vinyzu/patchright-nodejs#57) so this branch is checkable on
+	# its own. Revert to the upstream URL once that PR merges.
+	url = https://github.com/maestrojeong/patchright-nodejs.git
+	branch = fix/playwright-1.62-evaluate-isolated-context

--- a/driver_patches/crNetworkManagerPatch.ts
+++ b/driver_patches/crNetworkManagerPatch.ts
@@ -36,16 +36,17 @@ export function patchCRNetworkManager(project: Project) {
 	// -- _onRequest Method --
 	const onRequestMethod = crNetworkManagerClass.getMethodOrThrow("_onRequest");
 	// Find the route assignment, whether it is still pristine or already expanded.
+	const normalizeWhitespace = (text: string) => text.replace(/\s+/g, " ").trim();
 	const routeAssignment = assertDefined(
 		onRequestMethod.getDescendantsOfKind(SyntaxKind.BinaryExpression).find(expr => {
 			if (expr.getLeft().getText() !== "route") return false;
-			return expr
-				.getRight()
-				.getText()
-				.startsWith("new RouteImpl(requestPausedSessionInfo!.session, requestPausedEvent.requestId");
+			return normalizeWhitespace(expr.getRight().getText()).startsWith(
+				"new RouteImpl(requestPausedSessionInfo!.session, requestPausedEvent.requestId",
+			);
 		}),
 	);
-	// Adding new parameter to the RouteImpl call
+	// Adding new parameter to the RouteImpl call. Upstream may already construct RouteImpl with
+	// networkId (e.g. multi-line formatting), in which case this is a no-op replacement.
 	routeAssignment
 		.getRight()
 		.replaceWithText(

--- a/driver_patches/frameSelectorsPatch.ts
+++ b/driver_patches/frameSelectorsPatch.ts
@@ -30,6 +30,19 @@ export function patchFrameSelectors(project: Project) {
 	// ------- FrameSelectors Class -------
 	const frameSelectorsClass = frameSelectorsSourceFile.getClassOrThrow("FrameSelectors");
 
+	// Since Playwright v1.62, resolveFrameForSelector/resolveInjectedForSelector were made private
+	// (renamed to _resolveFrameForSelector/_resolveInjectedForSelector) and most call sites were
+	// rerouted through the new callOnSelector/callOnSelectorHandle batched API. Patchright's custom
+	// shadow-DOM-piercing logic (both here and in framesPatch.ts) still depends on calling these two
+	// methods directly and publicly from Frame, so restore their original public names/visibility.
+	for (const oldName of ["_resolveFrameForSelector", "_resolveInjectedForSelector"]) {
+		const method = frameSelectorsClass.getMethod(oldName);
+		if (method) {
+			method.setScope(undefined);
+			method.rename(oldName.slice(1));
+		}
+	}
+
 	// -- queryArrayInMainWorld Method --
 	const queryArrayInMainWorldMethod = frameSelectorsClass.getMethodOrThrow("queryArrayInMainWorld");
 	if (!queryArrayInMainWorldMethod.getParameter("isolatedContext"))
@@ -43,7 +56,8 @@ export function patchFrameSelectors(project: Project) {
 		.getDescendantsOfKind(SyntaxKind.CallExpression)
 		.find(
 			callExpr =>
-				callExpr.getExpression().getText() === "this.resolveInjectedForSelector" &&
+				(callExpr.getExpression().getText() === "this.resolveInjectedForSelector" ||
+					callExpr.getExpression().getText() === "this.callOnSelectorHandle") &&
 				callExpr.getArguments()[1]?.getKind() === SyntaxKind.ObjectLiteralExpression,
 		);
 	const mainWorldProp = assertDefined(

--- a/driver_patches/framesPatch.ts
+++ b/driver_patches/framesPatch.ts
@@ -117,14 +117,14 @@ export function patchFrames(project: Project) {
 		if (eventInitHandles.some(handle => handle._context?.frame !== this))
 			throw new js.JavaScriptErrorInEvaluate("JSHandles can be evaluated only in the context they were created!");
 		if (eventInitHandles.length === 0) {
-			await this._callOnElementOnceMatches(progress, selector, callback, { type, eventInit }, { ...options }, scope);
+			await this._waitForFunctionOnSelector(progress, selector, callback, { type, eventInit }, { ...options }, scope);
 			return;
 		}
 		try {
-			await this._callOnElementOnceMatches(progress, selector, callback, { type, eventInit }, { mainWorld: true, ...options }, scope);
+			await this._waitForFunctionOnSelector(progress, selector, callback, { type, eventInit }, { mainWorld: true, ...options }, scope);
 		} catch (e) {
 			if ("JSHandles can be evaluated only in the context they were created!" === e.message && canRetryInSecondaryContext) {
-				await this._callOnElementOnceMatches(progress, selector, callback, { type, eventInit }, { ...options }, scope);
+				await this._waitForFunctionOnSelector(progress, selector, callback, { type, eventInit }, { ...options }, scope);
 				return;
 			}
 			throw e;
@@ -855,7 +855,12 @@ export function patchFrames(project: Project) {
 		// The first expect check, a.k.a. one-shot, always finishes - even when progress is aborted.
 		if (noAbort)
 			progress = nullProgress;
-		const selectorInFrame = selector ? await progress.race(this.selectors.resolveFrameForSelector(selector, { strict: true })) : undefined;
+		// Since Playwright v1.62, expressions with no selector (e.g. to.have.title/to.have.url,
+		// checked directly on the page) fall back to querying ':root' (or 'body' for to.match.aria)
+		// so injected.expect() always receives a real element instead of undefined - matching
+		// upstream's own _expectInternal, whose injected.expect() no longer tolerates a missing one.
+		const effectiveSelector = selector ?? (options.expression === 'to.match.aria' ? 'body' : ':root');
+		const selectorInFrame = await progress.race(this.selectors.resolveFrameForSelector(effectiveSelector, { strict: true }));
 
 		const { frame, info } = selectorInFrame || { frame: this, info: undefined };
 		const world = options.expression === 'to.have.property' ? 'main' : (info?.world ?? 'utility');
@@ -876,6 +881,24 @@ export function patchFrames(project: Project) {
 				log = "  locator resolved to " + injected.previewNode(elements[0]);
 			if (info)
 				injected.checkDeprecatedSelectorUsage(info.parsed, elements);
+			// Since Playwright v1.62, injected.expect() requires a resolved element and no longer
+			// handles the "selector matched nothing" case itself (that special-casing moved to the
+			// server-side caller upstream, via callOnSelector returning null). Replicate that
+			// fallback here so we don't crash calling expectSingleElement(undefined, ...) below,
+			// e.g. while waiting for an iframe that hasn't loaded/attached yet. Exclude
+			// to.have.title/to.have.url: those read page-level state and never dereference the
+			// element, so they must keep working even when there's no selector (hence no elements).
+			if (!isArray && elements.length === 0 && options.expression !== 'to.have.title' && options.expression !== 'to.have.url') {
+				let matches = options.isNot;
+				let missingReceived = false;
+				if (!options.isNot && options.expression === 'to.be.hidden') matches = true;
+				else if (options.isNot && options.expression === 'to.be.visible') matches = false;
+				else if (!options.isNot && options.expression === 'to.be.detached') matches = true;
+				else if (options.isNot && options.expression === 'to.be.attached') matches = false;
+				else if (options.isNot && options.expression === 'to.be.in.viewport') matches = false;
+				else { matches = options.isNot; missingReceived = true; }
+				return { log, matches, missingReceived };
+			}
 			return { log, ...await injected.expect(elements[0], options, elements) };
 		}, { info, options, callId }));
 
@@ -892,8 +915,8 @@ export function patchFrames(project: Project) {
 		return { matches, received };
 	`);
 
-	// -- _callOnElementOnceMatches Method --
-	const callOnElementOnceMatchesMethod = frameClass.getMethodOrThrow("_callOnElementOnceMatches");
+	// -- _callOnElementOnceMatches Method (renamed to _waitForFunctionOnSelector upstream since v1.62) --
+	const callOnElementOnceMatchesMethod = frameClass.getMethod("_callOnElementOnceMatches") ?? frameClass.getMethodOrThrow("_waitForFunctionOnSelector");
 	callOnElementOnceMatchesMethod.setBodyText(`
 		const callbackText = body.toString();
 		progress.log("waiting for " + this._asLocator(selector));

--- a/utils/detection_smoke_test.mjs
+++ b/utils/detection_smoke_test.mjs
@@ -17,7 +17,9 @@ const pageHtml = `<!doctype html>
 const frameHtml = "<!doctype html><p>frame</p>";
 
 function evaluateInMainWorld(target, pageFunction, argument) {
-  return target.evaluate(pageFunction, argument, false);
+  // Since Playwright v1.62, evaluate()'s 3rd positional parameter is the new upstream
+  // `options` argument; Patchright's stealth `isolatedContext` flag was pushed to 4th position.
+  return target.evaluate(pageFunction, argument, undefined, false);
 }
 
 function detectLeaks() {

--- a/utils/modify_tests.ts
+++ b/utils/modify_tests.ts
@@ -34,6 +34,10 @@ const tsConfigPath = path.join(testsRoot, "tsconfig.json");
 const dryRun = process.env.MODIFY_TESTS_DRY_RUN === "1";
 
 const TARGET_METHODS = new Set(["evaluate", "evaluateHandle", "evaluateAll"]);
+// Since Playwright v1.62, `evaluate`/`evaluateHandle` gained a new `options` parameter that sits
+// right before Patchright's appended `isolatedContext` flag, so callers now need an extra
+// placeholder argument for it. `evaluateAll` did not gain such a parameter.
+const METHODS_WITH_OPTIONS_PARAM = new Set(["evaluate", "evaluateHandle"]);
 const TEST_BASE_NAMES = new Set(["it", "test", "playwrightTest"]);
 
 class SourceTextEditor {
@@ -462,13 +466,19 @@ function shouldSkipForSafety(callExpression: CallExpression): boolean {
 }
 
 function insertIsolatedContextArgument(callExpression: CallExpression): boolean {
+	const expression = callExpression.getExpression();
+	const methodName = Node.isPropertyAccessExpression(expression) ? expression.getName() : undefined;
+	const needsOptionsPlaceholder = !!methodName && METHODS_WITH_OPTIONS_PARAM.has(methodName);
+
 	const args = callExpression.getArguments();
 	if (args.length === 1) {
 		callExpression.addArgument("undefined");
+		if (needsOptionsPlaceholder) callExpression.addArgument("undefined");
 		callExpression.addArgument("false");
 		return true;
 	}
 	if (args.length === 2) {
+		if (needsOptionsPlaceholder) callExpression.addArgument("undefined");
 		callExpression.addArgument("false");
 		return true;
 	}


### PR DESCRIPTION
Fixes the automated v1.62.0/v1.62.1 release failure reported in #228 and
picks up where the auto-scaffolded #229 left off (that PR contains no
actual fix, just the stub branch created by the release-failure bot).

## Root causes

Playwright v1.62 refactored iframe/selector resolution and reused/renamed
several internal APIs that Patchright's driver patches depend on directly:

- **`server/frames.ts`**: `_callOnElementOnceMatches` was renamed to
  `_waitForFunctionOnSelector` (same signature, reimplemented on top of the
  new batched selector API). Updated the patch and its call sites to the
  new name.

- **`server/frameSelectors.ts`**: `resolveFrameForSelector` and
  `resolveInjectedForSelector` were made **private**
  (`_resolveFrameForSelector`/`_resolveInjectedForSelector`), with most
  upstream call sites rerouted through a new `callOnSelector`/
  `callOnSelectorHandle` batched API. Patchright's custom shadow-DOM-piercing
  logic (in both `frames.ts` and `frameSelectors.ts`) still needs to call
  these two directly and publicly, so the patch now restores their original
  name/visibility rather than assuming the old public methods still exist.

- **`server/chromium/crNetworkManager.ts`**: the `_onRequest` patch matched
  the `RouteImpl(...)` construction as a single-line string; upstream
  reformatted the exact same call across multiple lines, so the match
  silently failed (the content Patchright wants was already there upstream).
  Matching is now whitespace-insensitive.

- **`server/frames.ts` (`_expectInternal`)** — a real behavioral regression,
  not just a build break: `injected.expect()` no longer accepts an
  `undefined` element (that "selector matched nothing" special-casing moved
  to the server-side caller upstream, via `callOnSelector` returning `null`
  *before* `injected.expect()` is ever invoked). Patchright's custom
  `_expectInternal` still unconditionally called
  `injected.expect(elements[0], ...)` even when zero elements were found,
  crashing with `Cannot read properties of undefined (reading
  'ownerDocument')` — e.g. `expect(locator).toHaveText(...)` on an iframe
  that hasn't attached/loaded yet (`selectors-frame.spec.ts` / `should click
  in lazy iframe`, `locator-frame.spec.ts` equivalent). Ported upstream's
  "no elements matched" fallback (the `to.be.hidden`/`visible`/`detached`/
  `attached`/`in.viewport` short-circuits) into the injected-script
  callback, and added the same `:root`/`body` default-selector fallback
  upstream uses for selector-less expressions like `to.have.title`/
  `to.have.url` so those still resolve a real element instead of `undefined`.

- **`utils/detection_smoke_test.mjs`, `utils/modify_tests.ts`** — both called
  `evaluate(fn, arg, isolatedContext)` assuming `isolatedContext` is the 3rd
  positional argument. v1.62 inserted a new `options` parameter before it
  client-side (see companion PR), pushing `isolatedContext` to 4th position.
  Updated both accordingly, including `modify_tests.ts`'s generic
  `evaluate`/`evaluateHandle`/`evaluateAll` argument-injection logic (it now
  knows which of those three methods gained the extra `options` slot).

Companion fix (same root cause, client side):
Kaliiiiiiiiii-Vinyzu/patchright-nodejs#57 — Playwright v1.62 added a new
`options` parameter to `Frame`/`Page`/`JSHandle` `evaluate()`/
`evaluateHandle()` right before where Patchright appends `isolatedContext`,
and the existing patches located that insertion point via fixed text/regex
matches that silently stopped matching (no error thrown, the argument was
just never threaded through correctly). This PR's `.gitmodules` temporarily
points the `patchright-nodejs` submodule at that fork/branch so this PR is
checkable and buildable on its own — please update it back to the upstream
URL + a fresh commit once #57 merges.

## Testing

- `npm run patch` completes without error against Playwright v1.62.1 (previously failed with `InvalidOperationError: Expected to find class method declaration named '_callOnElementOnceMatches'`).
- `npm run build` succeeds.
- `node utils/detection_smoke_test.mjs` passes.
- ~800 of Playwright's own chromium-page tests across `selectors-*`, `locator-*`, `frame-*`, `expect-*` pass locally (not the full suite, due to local resource constraints).

## Known remaining gap (not a regression — a brand-new v1.62 feature)

The new `Locator.waitForFunction()` API reuses the renamed
`_waitForFunctionOnSelector` primitive with "poll until the callback
returns truthy" semantics. Patchright's custom implementation instead
decides when to stop polling based on "an element was found" rather than
"the callback's return value is truthy" — which happens to work for every
*other* existing caller (they all wrap their result in `{ result: ... }`,
an object that's always truthy), but means `locator.waitForFunction()`
itself polls until timeout instead of resolving once its predicate becomes
true (`locator-wait-for-function.spec.ts`). Left out of this PR since fixing
it touches the same shared method used by `dispatchEvent`/`textContent`/
`innerText`/etc. and deserves its own focused change + tests rather than
being bundled into a release-unblocking fix.